### PR TITLE
Add Codex environment and contribution guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,15 @@
+# Guidelines for Codex Agents
+
+## Testing
+- After modifying website content or configuration, run `jekyll build` to ensure the site compiles.
+
+## Posts
+- Blog posts reside in `_posts/` and use the `YYYY-MM-DD-title.md` naming scheme.
+- Include YAML front matter with at least `title` and `layout` keys.
+
+## Pages and Assets
+- Place standalone pages in the repo root or appropriate folders.
+- Store images in `img/` or `assets/`.
+
+## Environment
+- The development environment is defined in `codex.yaml`.

--- a/codex.yaml
+++ b/codex.yaml
@@ -1,0 +1,15 @@
+# Codex environment configuration for LabOnoM.github.io
+
+description: |
+  Environment for building and previewing the BSGOU website built with Jekyll.
+  Includes Ruby and Jekyll for static site generation.
+
+environment_variables:
+  JEKYLL_ENV: development
+
+secrets: []
+
+setup_script: |
+  apt-get update
+  apt-get install -y ruby-full build-essential zlib1g-dev
+  gem install bundler jekyll


### PR DESCRIPTION
## Summary
- add configuration for running the site in Codex (`codex.yaml`)
- document repo-specific guidance for Codex agents (`AGENTS.md`)

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_6848404d780083208847e5ed132d3728