### PR TITLE
Fix slider typo

### DIFF
--- a/js/custom.js
+++ b/js/custom.js
@@ -14,7 +14,7 @@ $("#navigation").sticky({topSpacing:0});
         slideshow: true,                //Boolean: Animate slider automatically
 		slideshowSpeed: 5000,           //Integer: Set the speed of the slideshow cycling, in milliseconds
 		animationSpeed: 600,
-		controlNav: false,               //Boolean: Create navigation for paging control of each clide? Note: Leave true for manualControls usage
+		controlNav: false,               //Boolean: Create navigation for paging control of each slide? Note: Leave true for manualControls usage
 		directionNav: true,             //Boolean: Create navigation for previous/next navigation? (true/false)
 		prevText: "Previous",           //String: Set the text for the "previous" directionNav item
 		nextText: "Next",


### PR DESCRIPTION
## Summary
- fix a typo in `custom.js`

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68484e25c12083208b22aaf5f9213ef6