### PR TITLE
Fix badge bar responsive layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,31 +42,6 @@
 			.hover-pink:hover {
 			color: hotpink;
 			}
-			.badge-bar {
-				display: flex;
-				align-items: center;
-				gap: 10px;
-				padding: 8px 16px;
-				background: transparent;
-				z-index: 1002;
-				position: relative;
-			}
-			.badge-bar span {
-				flex: 1;
-			}
-
-			/* Responsive: stack badges on small screens */
-			@media (max-width: 700px) {
-				.badge-bar {
-					flex-direction: column;
-					align-items: flex-start;
-					gap: 6px;
-					padding: 8px 8px;
-				}
-				.badge-bar span {
-					display: none; /* disables the flex push */
-				}
-			}
 			#forkongithub a {
 				background:#000;
 				color:#fff;
@@ -163,7 +138,7 @@
 			display: flex;
 			justify-content: space-between;
 			align-items: center;
-			flex-wrap: wrap;
+			flex-wrap: nowrap;
 			padding: 8px 16px;
 			gap: 12px;
 			box-sizing: border-box;


### PR DESCRIPTION
## Summary
- remove duplicate `.badge-bar` CSS
- keep bar horizontal on large screens with `flex-wrap: nowrap`
- keep badges and buttons wrapping individually

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*

------
https://chatgpt.com/codex/tasks/task_e_6854f8326b54832087ffe18a10d49432